### PR TITLE
Data type fix, added error, handling 4d cubes

### DIFF
--- a/AegeanTools/BANE_fft.py
+++ b/AegeanTools/BANE_fft.py
@@ -259,7 +259,7 @@ def get_kernel(
             pix_per_beam = beam.minor / scales.min()
             logging.info(f"Pixels per beam: {pix_per_beam:0.1f}")
         except (ValueError, NoBeamException):
-            msg = "Could not parse beam from header - try specifying step size (--step-size)"
+            msg = "Could not parse beam from header - try specifying step size (--step-size) and box size (--box-size)"
             raise ValueError(msg)
 
     if step_size is None or step_size < 0:

--- a/AegeanTools/BANE_fft.py
+++ b/AegeanTools/BANE_fft.py
@@ -680,8 +680,15 @@ def bane_3d_loop(
         fits.open(bkg_file, memmap=True, mode="update") as bkg_hdul,
     ):
         rms = rms_hdul[ext].data
+        original_rms_shape = rms.data.shape
+        rms = rms.reshape((-1, original_rms_shape[-2], original_rms_shape[-1]))
+        
         bkg = bkg_hdul[ext].data
-        logging.info(f"Running BANE on plane {idx}")
+        original_bkg_shape = bkg.data.shape
+        bkg = bkg.reshape((-1, original_bkg_shape[-2], original_rms_shape[-1]))
+        
+
+        logging.info(f"Running BANE on plane {idx}, {bkg.data.shape=} {rms.data.shape=}")
         bkg[idx], rms[idx] = robust_bane(
             plane.astype(np.float32),
             header,

--- a/AegeanTools/BANE_fft.py
+++ b/AegeanTools/BANE_fft.py
@@ -247,6 +247,7 @@ def get_kernel(
     Returns:
         Tuple[NDArray[np.float32], float]: The kernel and sum of the kernel
     """
+    from radio_beam.beam import NoBeamException
 
     logging.info(f"{step_size=}, {box_size=}")
     if step_size is None or step_size < 0 or box_size is None or box_size < 0:
@@ -257,8 +258,8 @@ def get_kernel(
             scales = proj_plane_pixel_scales(WCS(header)) * u.deg / u.pixel
             pix_per_beam = beam.minor / scales.min()
             logging.info(f"Pixels per beam: {pix_per_beam:0.1f}")
-        except ValueError:
-            msg = "Could not parse beam from header - try specifying step size"
+        except (ValueError, NoBeamException):
+            msg = "Could not parse beam from header - try specifying step size (--step-size)"
             raise ValueError(msg)
 
     if step_size is None or step_size < 0:
@@ -794,7 +795,7 @@ def main(
     # Check for frequency axis and Stokes axis
     logging.info(f"Opening FITS file {fits_file}")
     with fits.open(fits_file, memmap=True, mode="denywrite") as hdul:
-        data = hdul[ext].data.astype(np.float32)
+        data = hdul[ext].data
         header = hdul[ext].header
 
     if all_in_mem:


### PR DESCRIPTION
In trying to run `BANE_fft` on a set of cubes generated by `fitscube` I encountered a series of comical errors. Some easy to get around, others annoying. this PR contains:

1 - removing of the `.astype(np.float32)` of the cube to be BANE'd. This would move the memory mapped dataset into memory, and for larger-than-memory files would crash the node
2 - added some notes and exception to the exceptioned raised should a beam not be in a fits heafer
3 - some array reshaping to handle turn 4-d cubes into 3-d ones when slicing data back together in the multiprocessing pool

I am not horribly familiar with all of this code and the corner cases that may exist. But, in so far as this works for me it seemingly does. The two questions:

1 - is the `NoBeamFoundException` raised in `radio_beam` new? Previously we were only catching a `ValueError` exception. So if this is indeed a new exception not found in earlier versiion of radio-beam we should consider setting a minimum version for it
2 - I am not sure enough of my tricksey trick to reshape the memory mapped value, and how the `idx` being operated over in the pool aligns. For the situation where a non-spatial dimension is of size 1 (like Stokes) it should not matter, but should all dimensions be larger than 1 than maybe we need to rethink this. Since all images are indepdent of one another we can always reshape to begin with before starting the bane_3d loop. 